### PR TITLE
validate spec fixtures

### DIFF
--- a/.github/workflows/validate-fixtures.yml
+++ b/.github/workflows/validate-fixtures.yml
@@ -1,0 +1,32 @@
+name: Validate spec fixtures
+
+on: push
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-java@v2
+      with:
+        distribution: "adopt"
+        java-version: "11" # LTS
+
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version:  "2.7"
+        bundler-cache: true
+
+    - name: Prepare validator
+      run: bundle exec rake validator:download
+
+    - name: Run validator
+      run: bundle exec rake validator:run
+
+    - uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: validation-results
+        path: validator/results/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,11 @@
 
 # rspec failure tracking
 .rspec_status
+
+# rbenv/rvm/...
+.ruby-version
+.ruby-gemset
+.gems/
+
+# validator working directory
+validator/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,13 @@ GEM
   specs:
     builder (3.2.4)
     diff-lcs (1.4.4)
+    httparty (0.18.1)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
+    mime-types (3.3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2021.0225)
+    multi_xml (0.6.0)
     rake (13.0.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -23,13 +30,16 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.2)
+    rubyzip (2.3.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  httparty
   rake (~> 13.0)
   rspec (~> 3.0)
+  rubyzip (~> 2.0)
   xrechnung!
 
 BUNDLED WITH

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,55 @@
+require "pathname"
 require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+namespace :validator do
+  VALIDATOR_SOURCES = {
+    tool: {
+      filename:    "validator/validationtool-1.4.1-standalone.jar",
+      release_url: "https://github.com/itplr-kosit/validator/releases/download/v1.4.1/validationtool-1.4.1.zip",
+    },
+    scenarios: {
+      filename:    "validator/scenarios.xml",
+      release_url: "https://github.com/itplr-kosit/validator-configuration-xrechnung/releases/download/release-2020-12-31/validator-configuration-xrechnung_2.0.1_2020-12-31.zip",
+    }
+  }
+
+  VALIDATOR_SOURCES.each do |_, v|
+    base    = Pathname.new(__dir__).join("validator")
+    zipfile = base.join(File.basename(v[:release_url]))
+
+    file zipfile do
+      require "httparty"
+
+      base.mkpath unless base.exist?
+
+      res = HTTParty.get(v[:release_url], follow_redirects: true)
+      File.open(zipfile, "wb") { |f| f.write res.body }
+    end
+
+    file v[:filename] => zipfile do
+      require "zip"
+
+      Zip::File.foreach(zipfile) do |entry|
+        entry.extract base.join(entry.name)
+      end
+    end
+  end
+
+  desc "Download official validator and scenarios"
+  task download: VALIDATOR_SOURCES.map { |_, v| v[:filename] }
+
+  desc "Run validator on test fixtures"
+  task run: :download do
+    fixtures  = Pathname.new(__dir__).join("spec/fixtures/*.xml")
+    output    = Pathname.new(__dir__).join("validator/results").tap(&:mkpath)
+    tool      = VALIDATOR_SOURCES[:tool][:filename]
+    scenarios = VALIDATOR_SOURCES[:scenarios][:filename]
+
+    sh "java -jar #{tool} -s #{scenarios} --output-directory #{output} --html --disable-gui #{fixtures}"
+  end
+end

--- a/xrechnung.gemspec
+++ b/xrechnung.gemspec
@@ -25,4 +25,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "builder", "~> 3.2"
+
+  spec.add_development_dependency "httparty"
+  spec.add_development_dependency "rubyzip", "~> 2.0"
 end


### PR DESCRIPTION
Run

	rake validator:run

to download and run the official KoSIT Validator on our spec fixtures.

This also adds a Github Action workflow to test this automatically. When the validation fails, the reports are uploaded to the workflow summary:

![image](https://user-images.githubusercontent.com/327411/114456118-c9760f00-9bdc-11eb-87d1-f2b6b414a6b8.png)
