### PR TITLE
Price: optional BaseQuantity.

### DIFF
--- a/lib/xrechnung/price.rb
+++ b/lib/xrechnung/price.rb
@@ -23,7 +23,7 @@ module Xrechnung
     def to_xml(xml)
       xml.cac :Price do
         xml.cbc :PriceAmount, *price_amount.xml_args
-        xml.cbc :BaseQuantity, *base_quantity.xml_args
+        xml.cbc(:BaseQuantity, *base_quantity.xml_args) unless base_quantity.nil?
         allowance_charge&.to_xml(xml)
       end
     end


### PR DESCRIPTION
`Price/BaseQuantity` is not mandatory per specs:
https://docs.peppol.eu/poacc/billing/3.0/syntax/ubl-invoice/cac-InvoiceLine/cac-Price/cbc-BaseQuantity/