### PR TITLE
Fix PartyLegalEntity and Party ordering issues

### DIFF
--- a/lib/xrechnung/party.rb
+++ b/lib/xrechnung/party.rb
@@ -47,6 +47,7 @@ module Xrechnung
     private
 
     def party_body(xml)
+      party_identification&.to_xml(xml)
       unless name.nil? # if blank? -> empty name tag
         xml.cac :PartyName do
           if name == ""
@@ -56,7 +57,6 @@ module Xrechnung
           end
         end
       end
-      party_identification&.to_xml(xml)
       postal_address&.to_xml(xml)
       party_tax_scheme&.to_xml(xml)
       party_legal_entity&.to_xml(xml)

--- a/lib/xrechnung/party_legal_entity.rb
+++ b/lib/xrechnung/party_legal_entity.rb
@@ -13,8 +13,8 @@ module Xrechnung
     # noinspection RubyResolve
     def to_xml(xml)
       xml.cac :PartyLegalEntity do
-        xml.cbc(:CompanyID, company_id) unless company_id.nil?
         xml.cbc :RegistrationName, registration_name
+        xml.cbc(:CompanyID, company_id) unless company_id.nil?
       end
     end
   end

--- a/spec/fixtures/scraps/party_legal_entity.xml
+++ b/spec/fixtures/scraps/party_legal_entity.xml
@@ -1,4 +1,4 @@
 <cac:PartyLegalEntity>
-  <cbc:CompanyID>DE 214365879</cbc:CompanyID>
   <cbc:RegistrationName>Harry Hirsch Holz- und Trockenbau</cbc:RegistrationName>
+  <cbc:CompanyID>DE 214365879</cbc:CompanyID>
 </cac:PartyLegalEntity>


### PR DESCRIPTION
The ordering of the following fields was invalid, because the spec wraps these fields in a <xsd:sequence> and they were not in order, producing XML that did not validate against the XSD

- Moved the CompanyID to the correct position in PartyLegalEntity
- Moved the PartyIdentification/ID to the correct position in Party