### PR TITLE
Add support for direct debit payment means

### DIFF
--- a/lib/xrechnung.rb
+++ b/lib/xrechnung.rb
@@ -11,6 +11,8 @@ require "xrechnung/party_tax_scheme"
 require "xrechnung/postal_address"
 require "xrechnung/party"
 require "xrechnung/payee_financial_account"
+require "xrechnung/payment_mandate"
+require "xrechnung/payee_party"
 require "xrechnung/payment_means"
 require "xrechnung/tax_total"
 require "xrechnung/tax_category"
@@ -223,6 +225,15 @@ module Xrechnung
     #   @return [Xrechnung::PaymentMeans]
     member :payment_means, type: Xrechnung::PaymentMeans
 
+    # PAYEE PARTY BG-10
+    #
+    # A group of business terms providing information about the Payee, i.e. the role that receives
+    # the payment. Shall be used when the Payee is different from the Seller.
+    #
+    # @!attribute payee_party
+    #   @return [Xrechnung::PayeeParty]
+    member :payee_party, type: Xrechnung::PayeeParty, optional: true
+
     # Payment terms BT-20
     #
     # Eine Textbeschreibung der Zahlungsbedingungen, die für den fälligen Zahlungsbetrag gelten (einschließlich
@@ -337,6 +348,10 @@ module Xrechnung
 
         xml.cac :PaymentMeans do
           payment_means&.to_xml(xml)
+        end
+
+        unless self.class.members[:payee_party].optional && payee_party.nil?
+          payee_party&.to_xml(xml)
         end
 
         xml.cac :PaymentTerms do

--- a/lib/xrechnung/party_identification.rb
+++ b/lib/xrechnung/party_identification.rb
@@ -6,10 +6,18 @@ module Xrechnung
     #   @return [String]
     member :id, type: String
 
+    # @!attribute scheme_id
+    #   @return [String]
+    member :scheme_id, type: String, optional: true
+
     # noinspection RubyResolve
     def to_xml(xml)
       xml.cac :PartyIdentification do
-        xml.cbc :ID, id
+        if scheme_id
+          xml.cbc :ID, id, schemeID: scheme_id
+        else
+          xml.cbc :ID, id
+        end
       end
     end
   end

--- a/lib/xrechnung/payee_party.rb
+++ b/lib/xrechnung/payee_party.rb
@@ -1,0 +1,36 @@
+module Xrechnung
+  # <cac:PayeeParty>
+  #   <cac:PartyIdentification>
+  #     <cbc:ID schemeID="SEPA">FR932874294</cbc:ID>
+  #   </cac:PartyIdentification>
+  #   <cac:PartyName>
+  #     <cbc:Name>Payee Name Ltd</cbc:Name>
+  #   </cac:PartyName>
+  # </cac:PayeeParty>
+  class PayeeParty
+    include MemberContainer
+
+    # @!attribute id
+    #   @return [String]
+    member :id, type: String
+
+    # @!attribute name
+    #   @return [String]
+    member :name, type: String, optional: true
+
+    # noinspection RubyResolve
+    def to_xml(xml)
+      xml.cac :PayeeParty do
+        xml.cac :PartyIdentification do
+          xml.cbc :ID, id, schemeID: "SEPA"
+        end
+
+        if name
+          xml.cac :PartyName do
+            xml.cbc :Name, name
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/xrechnung/payment_mandate.rb
+++ b/lib/xrechnung/payment_mandate.rb
@@ -1,0 +1,29 @@
+module Xrechnung
+  # <cac:PaymentMandate>
+  #    <cbc:ID>SEPA-MANDAT-123</cbc:ID>
+  #    <cac:PayerFinancialAccount>
+  #      <cbc:ID>DE02500105170137075030</cbc:ID>
+  #    </cac:PayerFinancialAccount>
+  # </cac:PaymentMandate>
+  class PaymentMandate
+    include MemberContainer
+
+    # @!attribute id
+    #   @return [String]
+    member :id, type: String
+
+    # @!attribute payer_financial_account_id
+    #   @return [String]
+    member :payer_financial_account_id, type: String
+
+    # noinspection RubyResolve
+    def to_xml(xml)
+      xml.cac :PaymentMandate do
+        xml.cbc :ID, id
+        xml.cac :PayerFinancialAccount do
+          xml.cbc :ID, payer_financial_account_id
+        end
+      end
+    end
+  end
+end

--- a/lib/xrechnung/payment_means.rb
+++ b/lib/xrechnung/payment_means.rb
@@ -20,10 +20,16 @@ module Xrechnung
     #   @return [Xrechnung::PayeeFinancialAccount]
     member :payee_financial_account, type: Xrechnung::PayeeFinancialAccount
 
+    # @!attribute payment_mandate
+    #   @return [Xrechnung::PaymentMandate]
+    member :payment_mandate, type: Xrechnung::PaymentMandate, optional: true
+
     # noinspection RubyResolve
     def to_xml(xml)
       xml.cbc :PaymentMeansCode, payment_means_code
       payee_financial_account&.to_xml(xml)
+      payment_mandate&.to_xml(xml)
+      xml.target!
     end
   end
 end

--- a/spec/fixtures/ruby/payee_party.rb
+++ b/spec/fixtures/ruby/payee_party.rb
@@ -1,0 +1,6 @@
+def build_payee_party
+  Xrechnung::PayeeParty.new(
+    id: "FR932874294",
+    name: "Payee Name Ltd",
+  )
+end

--- a/spec/fixtures/ruby/payment_mandate.rb
+++ b/spec/fixtures/ruby/payment_mandate.rb
@@ -1,0 +1,6 @@
+def build_payment_mandate
+  Xrechnung::PaymentMandate.new(
+    id: "SEPA-MANDAT-123",
+    payer_financial_account_id: "DE02500105170137075030",
+  )
+end

--- a/spec/fixtures/scraps/payee_party.xml
+++ b/spec/fixtures/scraps/payee_party.xml
@@ -1,0 +1,8 @@
+<cac:PayeeParty>
+  <cac:PartyIdentification>
+    <cbc:ID schemeID="SEPA">FR932874294</cbc:ID>
+  </cac:PartyIdentification>
+  <cac:PartyName>
+    <cbc:Name>Payee Name Ltd</cbc:Name>
+  </cac:PartyName>
+</cac:PayeeParty>

--- a/spec/fixtures/scraps/payment_mandate.xml
+++ b/spec/fixtures/scraps/payment_mandate.xml
@@ -1,0 +1,6 @@
+<cac:PaymentMandate>
+  <cbc:ID>SEPA-MANDAT-123</cbc:ID>
+  <cac:PayerFinancialAccount>
+    <cbc:ID>DE02500105170137075030</cbc:ID>
+  </cac:PayerFinancialAccount>
+</cac:PaymentMandate>

--- a/spec/xrechnung/payee_party_spec.rb
+++ b/spec/xrechnung/payee_party_spec.rb
@@ -1,0 +1,8 @@
+require "spec_helper"
+load("spec/fixtures/ruby/payee_party.rb")
+
+RSpec.describe Xrechnung::PayeeParty do
+  it "generates xml" do
+    expect_xml_eq_fixture(build_payee_party, "payee_party")
+  end
+end

--- a/spec/xrechnung/payment_mandate_spec.rb
+++ b/spec/xrechnung/payment_mandate_spec.rb
@@ -1,0 +1,8 @@
+require "spec_helper"
+load("spec/fixtures/ruby/payment_mandate.rb")
+
+RSpec.describe Xrechnung::PaymentMandate do
+  it "generates xml" do
+    expect_xml_eq_fixture(build_payment_mandate, "payment_mandate")
+  end
+end


### PR DESCRIPTION
Adds classes to build direct debit payment means:

- [PaymentMandate](https://docs.peppol.eu/poacc/billing/3.0/2024-Q2/syntax/ubl-invoice/cac-PaymentMeans/cac-PaymentMandate/)
- [PayeeParty](https://docs.peppol.eu/poacc/billing/3.0/2024-Q2/syntax/ubl-invoice/cac-PayeeParty/)