### PR TITLE
Fix empty field OrderReference/ID

### DIFF
--- a/lib/xrechnung.rb
+++ b/lib/xrechnung.rb
@@ -314,7 +314,9 @@ module Xrechnung
         unless self.class.members[:purchase_order_reference].optional && purchase_order_reference.nil? &&
                self.class.members[:sales_order_reference].optional && sales_order_reference.nil?
           xml.cac :OrderReference do
-            xml.cbc :ID, purchase_order_reference
+            unless self.class.members[:purchase_order_reference].optional && purchase_order_reference.nil?
+              xml.cbc :ID, purchase_order_reference
+            end
             unless self.class.members[:sales_order_reference].optional && sales_order_reference.nil?
               xml.cbc :SalesOrderID, sales_order_reference
             end


### PR DESCRIPTION
The spec is no longer allowing empty elements.

Specifying a sales_order_reference but _not_ a purchase_order_reference lead to having an empty OrderReference/ID field.

This is now fixed.