### PR TITLE
Tax Exemption Status reordering

### DIFF
--- a/lib/xrechnung/tax_category.rb
+++ b/lib/xrechnung/tax_category.rb
@@ -23,7 +23,7 @@ module Xrechnung
 
     # @!attribute percent
     #   @return [BigDecimal]
-    member :percent, type: BigDecimal, transform_value: ->(v) { BigDecimal(v, 0) }
+    member :percent, type: BigDecimal, transform_value: ->(v) { v.nil? ? nil : BigDecimal(v, 0) }
 
     # @!attribute tax_scheme_id
     #   @return [String]
@@ -41,14 +41,15 @@ module Xrechnung
     def to_xml(xml, root_tag_name: :TaxCategory)
       xml.cac root_tag_name do
         xml.cbc :ID, id
-        xml.cbc :Percent, format("%.2f", percent)
-        xml.cac :TaxScheme do
-          xml.cbc :ID, tax_scheme_id
-        end
+        xml.cbc :Percent, format("%.2f", percent) unless percent.nil?
 
         unless tax_exemption_reason_code.nil?
           xml.cbc :TaxExemptionReasonCode, tax_exemption_reason_code
           xml.cbc :TaxExemptionReason, tax_exemption_reason
+        end
+
+        xml.cac :TaxScheme do
+          xml.cbc :ID, tax_scheme_id
         end
       end
     end

--- a/spec/fixtures/scraps/tax_category.xml
+++ b/spec/fixtures/scraps/tax_category.xml
@@ -1,9 +1,9 @@
 <cac:TaxCategory>
   <cbc:ID>S</cbc:ID>
   <cbc:Percent>16.00</cbc:Percent>
+  <cbc:TaxExemptionReasonCode>VATEX-EU-S</cbc:TaxExemptionReasonCode>
+  <cbc:TaxExemptionReason>Exempt</cbc:TaxExemptionReason>
   <cac:TaxScheme>
     <cbc:ID>VAT</cbc:ID>
   </cac:TaxScheme>
-  <cbc:TaxExemptionReasonCode>VATEX-EU-S</cbc:TaxExemptionReasonCode>
-  <cbc:TaxExemptionReason>Exempt</cbc:TaxExemptionReason>
 </cac:TaxCategory>


### PR DESCRIPTION
The elements cbc:TaxExemptionReasonCode and cbc:TaxExemptionReason must come before cac:TaxScheme