### PR TITLE
Add line item level allowance charge

### DIFF
--- a/lib/xrechnung/allowance_charge.rb
+++ b/lib/xrechnung/allowance_charge.rb
@@ -24,7 +24,7 @@ module Xrechnung
 
     # @!attribute base_amount
     #   @return [Xrechnung::Currency]
-    member :base_amount, type: Xrechnung::Currency
+    member :base_amount, type: Xrechnung::Currency, optional: true
 
     # @!attribute tax_category
     #   @return [Xrechnung::TaxCategory]
@@ -35,7 +35,7 @@ module Xrechnung
         kwargs[:amount] = Currency::EUR(kwargs[:amount])
       end
 
-      unless kwargs[:base_amount].is_a?(Currency)
+      unless kwargs[:base_amount].is_a?(Currency) || kwargs[:base_amount].nil?
         kwargs[:base_amount] = Currency::EUR(kwargs[:base_amount])
       end
 
@@ -60,7 +60,10 @@ module Xrechnung
         end
 
         xml.cbc :Amount, *amount.xml_args
-        xml.cbc :BaseAmount, *base_amount.xml_args
+
+        if base_amount
+          xml.cbc :BaseAmount, *base_amount.xml_args
+        end
 
         tax_category&.to_xml(xml)
       end

--- a/lib/xrechnung/invoice_line.rb
+++ b/lib/xrechnung/invoice_line.rb
@@ -28,6 +28,10 @@ module Xrechnung
     #   @return [Xrechnung::Price]
     member :price, type: Xrechnung::Price
 
+    # @!attribute allowance_charges
+    #   @return [Array<Xrechnung::AllowanceCharge>]
+    member :allowance_charges, type: Array, default: []
+
     def initialize(**kwargs)
       unless kwargs[:line_extension_amount].is_a?(Currency)
         kwargs[:line_extension_amount] = Currency::EUR(kwargs[:line_extension_amount])
@@ -43,6 +47,9 @@ module Xrechnung
         xml.cbc :LineExtensionAmount, *line_extension_amount.xml_args
 
         invoice_period&.to_xml(xml) unless self.class.members[:invoice_period].optional && invoice_period.nil?
+        allowance_charges.each do |allowance_charge|
+          allowance_charge.to_xml(xml)
+        end
         item&.to_xml(xml)
         price&.to_xml(xml)
       end

--- a/spec/fixtures/ruby/allowance_charge.rb
+++ b/spec/fixtures/ruby/allowance_charge.rb
@@ -2,6 +2,15 @@ def build_allowance_charge
   Xrechnung::AllowanceCharge.new(
     charge_indicator: false,
     amount:           1,
-    base_amount:      1295.30,
+    base_amount:      1296.30,
+  )
+end
+
+def build_line_item_allowance_charge
+  Xrechnung::AllowanceCharge.new(
+    charge_indicator:             false,
+    amount:                       1,
+    allowance_charge_reason:      "Rabatt",
+    allowance_charge_reason_code: 95,
   )
 end

--- a/spec/fixtures/ruby/invoice_line.rb
+++ b/spec/fixtures/ruby/invoice_line.rb
@@ -10,3 +10,14 @@ def build_invoice_line
     price:                 build_price,
   )
 end
+
+def build_invoice_line_with_allowance_charge
+  Xrechnung::InvoiceLine.new(
+    id:                    0,
+    invoiced_quantity:     Xrechnung::Quantity.new(1, "XPP"),
+    line_extension_amount: 1294.30,
+    item:                  build_item,
+    price:                 build_price,
+    allowance_charges:     [build_line_item_allowance_charge],
+  )
+end

--- a/spec/fixtures/ruby/price.rb
+++ b/spec/fixtures/ruby/price.rb
@@ -2,7 +2,7 @@ load("spec/fixtures/ruby/allowance_charge.rb")
 
 def build_price
   Xrechnung::Price.new(
-    price_amount:     1294.30,
+    price_amount:     1295.30,
     base_quantity:    Xrechnung::Quantity.new(1, "XPP"),
     allowance_charge: build_allowance_charge,
   )

--- a/spec/fixtures/scraps/allowance_charge.xml
+++ b/spec/fixtures/scraps/allowance_charge.xml
@@ -1,5 +1,5 @@
 <cac:AllowanceCharge>
   <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
   <cbc:Amount currencyID="EUR">1.00</cbc:Amount>
-  <cbc:BaseAmount currencyID="EUR">1295.30</cbc:BaseAmount>
+  <cbc:BaseAmount currencyID="EUR">1296.30</cbc:BaseAmount>
 </cac:AllowanceCharge>

--- a/spec/fixtures/scraps/invoice_line.xml
+++ b/spec/fixtures/scraps/invoice_line.xml
@@ -17,12 +17,12 @@
     </cac:ClassifiedTaxCategory>
   </cac:Item>
   <cac:Price>
-    <cbc:PriceAmount currencyID="EUR">1294.30</cbc:PriceAmount>
+    <cbc:PriceAmount currencyID="EUR">1295.30</cbc:PriceAmount>
     <cbc:BaseQuantity unitCode="XPP">1.00</cbc:BaseQuantity>
     <cac:AllowanceCharge>
       <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
       <cbc:Amount currencyID="EUR">1.00</cbc:Amount>
-      <cbc:BaseAmount currencyID="EUR">1295.30</cbc:BaseAmount>
+      <cbc:BaseAmount currencyID="EUR">1296.30</cbc:BaseAmount>
     </cac:AllowanceCharge>
   </cac:Price>
 </cac:InvoiceLine>

--- a/spec/fixtures/scraps/price.xml
+++ b/spec/fixtures/scraps/price.xml
@@ -1,9 +1,9 @@
 <cac:Price>
-  <cbc:PriceAmount currencyID="EUR">1294.30</cbc:PriceAmount>
+  <cbc:PriceAmount currencyID="EUR">1295.30</cbc:PriceAmount>
   <cbc:BaseQuantity unitCode="XPP">1.00</cbc:BaseQuantity>
   <cac:AllowanceCharge>
     <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
     <cbc:Amount currencyID="EUR">1.00</cbc:Amount>
-    <cbc:BaseAmount currencyID="EUR">1295.30</cbc:BaseAmount>
+    <cbc:BaseAmount currencyID="EUR">1296.30</cbc:BaseAmount>
   </cac:AllowanceCharge>
 </cac:Price>

--- a/spec/fixtures/xrechnung.xml
+++ b/spec/fixtures/xrechnung.xml
@@ -159,6 +159,12 @@
     <cbc:ID>0</cbc:ID>
     <cbc:InvoicedQuantity unitCode="XPP">1.00</cbc:InvoicedQuantity>
     <cbc:LineExtensionAmount currencyID="EUR">1294.30</cbc:LineExtensionAmount>
+    <cac:AllowanceCharge>
+      <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
+      <cbc:AllowanceChargeReasonCode>95</cbc:AllowanceChargeReasonCode>
+      <cbc:AllowanceChargeReason>Rabatt</cbc:AllowanceChargeReason>
+      <cbc:Amount currencyID="EUR">1.00</cbc:Amount>
+    </cac:AllowanceCharge>
     <cac:Item>
       <cbc:Description>Leimbinder 2x18m; Birke</cbc:Description>
       <cbc:Name>Leimbinder</cbc:Name>
@@ -174,12 +180,12 @@
       </cac:ClassifiedTaxCategory>
     </cac:Item>
     <cac:Price>
-      <cbc:PriceAmount currencyID="EUR">1294.30</cbc:PriceAmount>
+      <cbc:PriceAmount currencyID="EUR">1295.30</cbc:PriceAmount>
       <cbc:BaseQuantity unitCode="XPP">1.00</cbc:BaseQuantity>
       <cac:AllowanceCharge>
         <cbc:ChargeIndicator>false</cbc:ChargeIndicator>
         <cbc:Amount currencyID="EUR">1.00</cbc:Amount>
-        <cbc:BaseAmount currencyID="EUR">1295.30</cbc:BaseAmount>
+        <cbc:BaseAmount currencyID="EUR">1296.30</cbc:BaseAmount>
       </cac:AllowanceCharge>
     </cac:Price>
   </cac:InvoiceLine>

--- a/spec/xrechnung_spec.rb
+++ b/spec/xrechnung_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe Xrechnung do
 
     doc.legal_monetary_total = build_legal_monetary_total
 
-    doc.invoice_lines << build_invoice_line
+    doc.invoice_lines << build_invoice_line_with_allowance_charge
 
     doc.invoice_lines << Xrechnung::InvoiceLine.new(
       id:                    1,


### PR DESCRIPTION
The standard allows for AllowanceCharge on the line item level. This is now added and must be an array, because there can be multiple AllowanceCharges (think multiple discounts).

The base_amount is optional in the standard, so we don't require it anymore.